### PR TITLE
JENKINS-50772: Enhance uploadFile so that it optionally sets a "Content-Type" header.

### DIFF
--- a/src/main/java/io/jenkins/plugins/httpclient/RobustHTTPClient.java
+++ b/src/main/java/io/jenkins/plugins/httpclient/RobustHTTPClient.java
@@ -239,9 +239,16 @@ public final class RobustHTTPClient implements Serializable {
      * Upload a file to a URL.
      */
     public void uploadFile(File f, URL url, TaskListener listener) throws IOException, InterruptedException {
+        uploadFile(f, null, url, listener);
+    }
+
+    public void uploadFile(File f, String contentType, URL url, TaskListener listener) throws IOException, InterruptedException {
         connect("upload", "upload " + f + " to " + sanitize(url), client -> {
             HttpPut put = new HttpPut(url.toString());
             put.setEntity(new FileEntity(f));
+            if (contentType != null) {
+                put.setHeader("Content-Type", contentType);
+            }
             return client.execute(put);
         }, response -> {}, listener);
     }


### PR DESCRIPTION
In order to fix JENKINS-50772, it is necessary to specify the "Content-Type" header when uploading files. In this commit, we change RobustHTTPClient to accept a content type parameter for an uploaded file. This is a prerequisite for further changes on the artifact-manager-s3 side, where the content type is determined and then passed in to the AWS signed URL generation code. In order to work with those signed URLs which include a content type header, we also need to ensure the upload code specifies the same header when uploading the file.

The existing RobustHTTPClient `uploadFile(File, URL, TaskListener)` method signature is preserved, and changed to call the new `uploadFile(File, String, URL, TaskListener)` which includes an additional parameter for specifying the content type. If this is non-null, the "Content-Type" HTTP header will be set accordingly. This is necessary, or the presigned URL which included the "Content-Type" header, and the `GET` request used to perform the upload do not match and will throw an AWS exception complaining that "The request signature we calculated does not match the signature you provided."